### PR TITLE
Use :i for info

### DIFF
--- a/haskell-ucs.tex
+++ b/haskell-ucs.tex
@@ -335,7 +335,7 @@ boolean comparisons and list membership, which are non-associative.  Default is
 	\li[GHCi turn off stats]      \verb+>+ :unset +s
 	\li[GHCi help]                \verb+>+ :?
 	\li[Type of an expression]    \verb+>+ :t \I{expr}
-	\li[Info (oper./func./class)] \verb+>+ :info \I{thing}
+	\li[Info (oper./func./class)] \verb+>+ :i \I{thing}
 \end{ldesc}
 
 \end{document} 


### PR DESCRIPTION
To make the GHC command consistent with the other short versions.
