### PR TITLE
Fix a minor English mistake

### DIFF
--- a/haskell-ucs.tex
+++ b/haskell-ucs.tex
@@ -187,7 +187,7 @@ boolean comparisons and list membership, which are non-associative.  Default is
 
 \newcommand{\emptyarray}{[]}
 \begin{ldesc}
-	\li[apply f for each x in xs]   map f xs
+	\li[apply f to each x in xs]   map f xs
 	\li[\s\s returning new list]    \s\s:: (a -> b) -> [a] -> [b]
 	\li[fold - (z + left) `to` right]   foldl f z xs \li
 										\s\s\small{}:: (a -> b -> a) -> a -> [b] -> a


### PR DESCRIPTION
You apply a function _to_ its argument.
